### PR TITLE
Add option to use alternative tmpdir (/var/tmp)

### DIFF
--- a/data/schemas/com.uploadedlobster.peek.gschema.xml
+++ b/data/schemas/com.uploadedlobster.peek.gschema.xml
@@ -18,6 +18,10 @@
       <default>true</default>
       <summary>Prefer dark theme</summary>
     </key>
+    <key name="recording-alternative-tmpdir" type="b">
+      <default>false</default>
+      <summary>Use alternative temporary directory. Enable this option if you experience system lag when creating gifs.</summary>
+    </key>
     <key name="recording-start-delay" type="i">
       <range min="0" max="60"/>
       <default>3</default>

--- a/src/application-window.vala
+++ b/src/application-window.vala
@@ -257,9 +257,15 @@ namespace Peek {
     private void maybe_set_tmpdir () {
       if (this.alternative_tmpdir) {
         var tmpdir = Environment.get_variable ("TMPDIR");
+        var magick_tmpdir = Environment.get_variable ("MAGICK_TMPDIR");
 
         if ("/var/tmp" != tmpdir) {
           Environment.set_variable ("TMPDIR", "/var/tmp", true);
+        }
+
+        if ("/var/tmp" != magick_tmpdir) {
+          Environment.set_variable ("MAGICK_TMPDIR", "/var/tmp", true);
+          Environment.set_variable ("MAGICK_TEMPORARY_PATH", "/var/tmp", true);
         }
       }
     }

--- a/src/application-window.vala
+++ b/src/application-window.vala
@@ -24,6 +24,8 @@ namespace Peek {
 
     public int size_indicator_delay { get; set; }
 
+    public bool alternative_tmpdir { get; set; }
+
     public int recording_start_delay { get; set; }
 
     public string default_file_name_format { get; set; }
@@ -94,6 +96,10 @@ namespace Peek {
         this.get_settings (), "gtk_application_prefer_dark_theme",
         SettingsBindFlags.DEFAULT);
 
+      settings.bind ("recording-alternative-tmpdir",
+        this, "alternative_tmpdir",
+        SettingsBindFlags.DEFAULT);
+
       settings.bind ("recording-framerate",
         this.recorder, "framerate",
         SettingsBindFlags.DEFAULT);
@@ -110,6 +116,8 @@ namespace Peek {
       this.set_keep_above (true);
       this.load_geometry ();
       this.on_window_screen_changed (null);
+
+      this.maybe_set_tmpdir ();
     }
 
     public override bool configure_event (Gdk.EventConfigure event) {
@@ -243,6 +251,16 @@ namespace Peek {
         stop_button.set_label (_ ("Rendering…"));
         recorder.stop ();
         show_file_chooser ();
+      }
+    }
+
+    private void maybe_set_tmpdir () {
+      if (this.alternative_tmpdir) {
+        var tmpdir = Environment.get_variable ("TMPDIR");
+
+        if ("/var/tmp" != tmpdir) {
+          Environment.set_variable ("TMPDIR", "/var/tmp", true);
+        }
       }
     }
 

--- a/src/preferences-dialog.vala
+++ b/src/preferences-dialog.vala
@@ -38,6 +38,9 @@ namespace Peek {
     private Gtk.CheckButton interface_open_file_manager;
 
     [GtkChild]
+    private Gtk.Switch recording_alternative_tmpdir;
+
+    [GtkChild]
     private Gtk.Adjustment recording_start_delay;
 
     [GtkChild]
@@ -50,6 +53,10 @@ namespace Peek {
 
       settings.bind ("interface-open-file-manager",
         interface_open_file_manager, "active",
+        SettingsBindFlags.DEFAULT);
+
+      settings.bind ("recording-alternative-tmpdir",
+        recording_alternative_tmpdir, "state",
         SettingsBindFlags.DEFAULT);
 
       settings.bind ("recording-start-delay",

--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -136,6 +136,7 @@ Author: Philipp Wolfer <ph.wolfer@gmail.com>
               <object class="GtkBox" id="recording_alternative_tmpdir_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Enable this option if you experience system lag when creating gifs.</property>
                 <property name="spacing">12</property>
                 <property name="homogeneous">True</property>
                 <child>
@@ -144,12 +145,25 @@ Author: Philipp Wolfer <ph.wolfer@gmail.com>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">Use alternative temporary directory.</property>
+                    <property name="label" translatable="yes">Use alternative temporary directory. </property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="recording_alternative_tmpdir">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>
@@ -199,7 +213,7 @@ Author: Philipp Wolfer <ph.wolfer@gmail.com>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
@@ -241,7 +255,7 @@ Author: Philipp Wolfer <ph.wolfer@gmail.com>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>

--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -133,6 +133,33 @@ Author: Philipp Wolfer <ph.wolfer@gmail.com>
               </packing>
             </child>
             <child>
+              <object class="GtkBox" id="recording_alternative_tmpdir_box">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="spacing">12</property>
+                <property name="homogeneous">True</property>
+                <child>
+                  <object class="GtkLabel" id="recording_alternative_tmpdir_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Use alternative temporary directory.</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkBox" id="recording_start_delay_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>


### PR DESCRIPTION
~~### W.I.P (Not ready to merge)~~

~~This isn't ready to be merged. Its not working. Ffmpeg uses the alternative tmpdir but imagemagick  does not for some reason. I will try to figure it out as soon as I can (find the time to do it). Of course if the issue is obvious please do let me know :sweat_smile:~~


***Update 11/23/2016:*** Looks like its working now. Should be tested by someone else to confirm though! 
Fixes #25 Fixes #2 @phw 