### PR TITLE
Update the installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ am working on it ;)
 On Ubuntu 16.04 Xenial:
 ```
 $ wget https://github.com/phw/peek/releases/download/v0.8.0/peek-0.8.0-Linux.deb
-$ sudo apt install libsdl1.2debian ffmpeg libavdevice-ffmpeg56
+$ sudo apt-get install libsdl1.2debian ffmpeg libavdevice-ffmpeg56
 $ sudo dpkg -i peek-0.8.0-Linux.deb
 $ peek
 ```


### PR DESCRIPTION
I realized early that there was a typo error in the 'apt' command in the installation guide while writing [an entry in my blog](https://julioecheverri.wordpress.com/2017/01/18/graba-tu-pantalla-como-un-gif-en-linux/) about **peek**. 
Sorry, it's now fixed.