### PR TITLE
Snappy install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Simple screen recorder with an easy to use interface
 - [Installation](#installation)
   - [Official distribution packages](#official-distribution-packages)
   - [Flatpak](#flatpak)
+  - [Snappy](#snappy)
   - [Arch Linux](#arch-linux)
   - [Ubuntu](#ubuntu)
   - [Debian](#debian)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ To update to the latest version run:
 To test the latest development version you can install
 [peek-master.flatpakref](http://flatpak.uploadedlobster.com/peek-master.flatpakref)
 
+### Snappy
+Peek can also be installed on all distributions supporting [Snappy](https://snapcraft.io/docs/core/install).
+Currently only the development version is available in the Snappy format:
+
+    sudo snap install peek --edge --devmode
+
 ### Arch Linux
 For Arch Linux
 [peek](https://aur.archlinux.org/packages/peek/) is available in the AUR. You


### PR DESCRIPTION
This would give me a cheeky Contributor tag but it does help with #84 although arguably the Snap is not consumer-ready and we should wait until it works properly in strict and is released in stable until editing?

Feel free to close.

Sorry for not squashing the commits, not sure how I can do that easily.