### PR TITLE
Added update instruction to Snappy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Peek can also be installed on all distributions supporting [Snappy](https://snap
 Currently only the development version is available in the Snappy format:
 
     sudo snap install peek --edge --devmode
+    
+Because the Snap is unconfined, you will need to manually update Peek (there are daily builds, so you could update it daily)
+
+    sudo snap refresh peek --devmode
 
 ### Arch Linux
 For Arch Linux


### PR DESCRIPTION
Edit: DO NOT MERGE (yet)

Probably as a security measure, unconfined Snaps don't update automatically. I've added the command for manually updating the Peek Snap.

Of course hopefully the last few bugs with the confined Snap will be ironed out (#84) and then it can be released in confinement and will automatically update!