### PR TITLE
Shaped window without compositor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Version 1.?.? - 2017-??-??
+ * feat: Transparent recording area without compositor (#147, #7)
+
 # Version 1.0.3 - 2017-06-13
  * package: fixed installing man page
  * package: fixed Debian packaging

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Simple screen recorder with an easy to use interface
   - [From source](#from-source)
 - [Frequently Asked Questions](#frequently-asked-questions)
   - [How can I capture mouse clicks and/or key strokes?](#how-can-i-capture-mouse-clicks-andor-key-strokes)
-  - [The recording area is all black, how can I record anything?](#the-recording-area-is-all-black-how-can-i-record-anything)
   - [My recorded GIFs flicker, what is wrong?](#my-recorded-gifs-flicker-what-is-wrong)
   - [Why can't I interact with the UI elements inside the recording area?](#why-cant-i-interact-with-the-ui-elements-inside-the-recording-area)
   - [Why are the GIF files so big?](#why-are-the-gif-files-so-big)
@@ -63,7 +62,6 @@ Support for more Wayland desktops might be added in the future (see FAQs below).
 - [libkeybinder3](https://github.com/kupferlauncher/keybinder)
 - FFmpeg or libav-tools
 - ImageMagick
-- Window manager with compositing enabled
 
 ### Development
 
@@ -207,12 +205,6 @@ like [key-mon](https://github.com/critiqjo/key-mon) which is usually included
 in most distributions, so you can easily install with your package manager.
 Then start key-mon with `key-mon --visible_click`. The `--visible_click` option
 is for drawing small circles around mouse clicks.
-
-### The recording area is all black, how can I record anything?
-If the recording area is not showing the content behind Peek you have probably
-compositing disabled in your window manager. Peek requires compositing in order
-to make the Peek window transparent. Please consult your window manager's
-documentation how to enable compositing.
 
 ### My recorded GIFs flicker, what is wrong?
 Some users have experienced recorded windows flicker or other strange visual

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ Currently only the development version is available in the Snappy format:
 
     sudo snap install peek --edge --devmode
 
+Once installed you can run Peek via its application icon in your desktop
+environment or from command line:
+
+    snap run peek
+
 ### Arch Linux
 For Arch Linux
 [peek](https://aur.archlinux.org/packages/peek/) is available in the AUR. You

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Simple screen recorder with an easy to use interface
 - [Frequently Asked Questions](#frequently-asked-questions)
   - [How can I capture mouse clicks and/or key strokes?](#how-can-i-capture-mouse-clicks-andor-key-strokes)
   - [My recorded GIFs flicker, what is wrong?](#my-recorded-gifs-flicker-what-is-wrong)
-  - [Why can't I interact with the UI elements inside the recording area?](#why-cant-i-interact-with-the-ui-elements-inside-the-recording-area)
   - [Why are the GIF files so big?](#why-are-the-gif-files-so-big)
   - [If GIF is so bad why use it at all?](#if-gif-is-so-bad-why-use-it-at-all)
   - [What about WebM or MP4? Those are well supported on the web.](#what-about-webm-or-mp4-those-are-well-supported-on-the-web)
+  - [Why can't I interact with the UI elements inside the recording area?](#why-cant-i-interact-with-the-ui-elements-inside-the-recording-area)
+  - [On i3 the recording area is all black, how can I record anything?](#on-i3-the-recording-area-is-all-black-how-can-i-record-anything)
   - [Why no native Wayland support?](#why-no-native-wayland-support)
 - [Contribute](#contribute)
   - [Development](#development-1)
@@ -214,12 +215,6 @@ acceleration methods can help. For NVIDIA drivers changing the "Allow Flipping"
 setting in the NVIDIA control panel
 [was reported to help](https://github.com/phw/peek/issues/86).
 
-### Why can't I interact with the UI elements inside the recording area?
-You absolutely should be able to click the UI elements inside the area you are
-recording. However this does not work as intended on some window managers,
-most notably i3. If this does not work for you on any other window manager
-please open an [issue on Github](https://github.com/phw/peek/issues).
-
 ### Why are the GIF files so big?
 Peek is using ImageMagick to optimize the GIF files and reduce the file size.
 As was shown in
@@ -252,6 +247,16 @@ Peek allows you to record in both WebM and MP4 format, just choose your
 preferred output format in the preferences. Both are well supported by modern
 browsers, even though they are still not as universally supported by tools and
 online services as GIFs.
+
+### Why can't I interact with the UI elements inside the recording area?
+You absolutely should be able to click the UI elements inside the area you are
+recording. However this does not work as intended on some window managers,
+most notably i3. If this does not work for you on any other window manager
+please open an [issue on Github](https://github.com/phw/peek/issues).
+
+### On i3 the recording area is all black, how can I record anything?
+i3 does not support the X shape extension. In order to get a transparent
+recording area you have to run a compositor such as Compton.
 
 ### Why no native Wayland support?
 Wayland has two restrictions that make it hard for Peek to support Wayland

--- a/debian/control
+++ b/debian/control
@@ -29,5 +29,3 @@ Description: Simple animated GIF screen recorder with an easy to use interface
  showing UI features of your own apps or for showing a bug in bug reports. It is
  not a general purpose screencast app with extended features and it never
  will be.
- .
- It also requires a window manager with compositing enabled.

--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -403,11 +403,13 @@ namespace Peek.Ui {
 
       this.input_shape_combine_region (window_region);
 
-      if (delay_indicator_timeout == 0 &&
-        size_indicator_timeout == 0) {
-        this.shape_combine_region (window_region);
-      } else {
-        this.shape_combine_region (null);
+      if (!this.get_screen ().is_composited ()) {
+        if (delay_indicator_timeout == 0 &&
+          size_indicator_timeout == 0) {
+          this.shape_combine_region (window_region);
+        } else {
+          this.shape_combine_region (null);
+        }
       }
     }
 

--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -212,12 +212,17 @@ namespace Peek.Ui {
     }
 
     [GtkCallback]
+    private bool on_window_draw (Widget widget, Context ctx) {
+      update_input_shape ();
+
+      return false;
+    }
+
+    [GtkCallback]
     private bool on_recording_view_draw (Widget widget, Context ctx) {
       // Stance out the transparent inner part
       ctx.set_operator (Operator.CLEAR);
       ctx.paint ();
-
-      update_input_shape ();
 
       return false;
     }

--- a/ui/application-window.ui
+++ b/ui/application-window.ui
@@ -49,6 +49,7 @@ Author: Philipp Wolfer <ph.wolfer@gmail.com>
     <property name="icon_name">com.uploadedlobster.peek</property>
     <property name="show_menubar">False</property>
     <signal name="screen-changed" handler="on_window_screen_changed" swapped="no"/>
+    <signal name="draw" handler="on_window_draw" swapped="no"/>
     <child>
       <object class="GtkBox" id="content_area">
         <property name="visible">True</property>


### PR DESCRIPTION
This uses shaped windows to draw the transparent recording area, thus supporting window managers without compositing

@psychon I would appreciate your feedback on this. Some notes:

- RGBA is still enabled, as it is needed for the semi transparent overlays
- As RGBA is enabled anyway, I use the shaped window only when no compositing is available to avoid possible issues
- Shaped window is only enabled when there is no overlay, thus the overlays are still available as before even without compositing (just without alpha transparency of course)
- When the fallback app menu is used and no compositing is available (which is not unlikely to happen together) the app menu dropdown renders with a black background, but I guess this is just a necessary drawback in this case

  ![bildschirmfoto vom 2017-06-13 14-51-47](https://user-images.githubusercontent.com/29852/27083152-d9b65bfc-5047-11e7-97b8-9ba2fca089b2.png)

- Without compositing I sometimes had some rendering artifacts of the window border left over outside the window after resizing (tested on XFCE). But it is hard to reproduce, in my last testing just now I could not reproduce it a single time.

I have not yet tested on Awesome WM or i3, but will do so next.

## Todo

[x] Test on awesome: awesome 4 is working, awesome 3 not
[x] Test on i3: not working due to missing shape extension
[x] Updated README and CHANGES
