### PR TITLE
Use CMAKE_INSTALL_DATAROOTDIR to allow different prefixes for bin and share

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,10 @@ set (PEEK_VERSION_MAJOR 1)
 set (PEEK_VERSION_MINOR 0)
 set (PEEK_VERSION_PATCH 3)
 
-set (XDG_APPS_INSTALL_DIR share/applications)
+set (XDG_APPS_INSTALL_DIR ${CMAKE_INSTALL_DATAROOTDIR}/applications)
 set (GettextTranslate_GMO_BINARY TRUE)
 set (GettextTranslate_ALL TRUE)
-set (LOCALEDIR ${CMAKE_INSTALL_PREFIX}/share/locale)
+set (LOCALEDIR ${CMAKE_INSTALL_DATAROOTDIR}/locale)
 
 # Include macros for Vala and GLib
 list(APPEND CMAKE_MODULE_PATH

--- a/cmake/GSettings.cmake
+++ b/cmake/GSettings.cmake
@@ -17,7 +17,7 @@ macro(add_schema SCHEMA_NAME)
     set(PKG_CONFIG_EXECUTABLE pkg-config)
     # Have an option to not install the schema into where GLib is
     if (GSETTINGS_LOCALINSTALL)
-        SET (GSETTINGS_DIR "${CMAKE_INSTALL_PREFIX}/share/glib-2.0/schemas/")
+        SET (GSETTINGS_DIR "${CMAKE_INSTALL_DATAROOTDIR}/glib-2.0/schemas/")
     else ()
         execute_process (COMMAND ${PKG_CONFIG_EXECUTABLE} glib-2.0 --variable prefix OUTPUT_VARIABLE _glib_prefix OUTPUT_STRIP_TRAILING_WHITESPACE)
         SET (GSETTINGS_DIR "${_glib_prefix}/share/glib-2.0/schemas/")

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -43,24 +43,24 @@ if(GETTEXT_VERSION_STRING VERSION_EQUAL GETTEXT_REQUIRED_VERSION OR GETTEXT_VERS
   add_custom_target(build-appdata-file ALL DEPENDS com.uploadedlobster.peek.appdata.xml)
   install(
     FILES ${CMAKE_BINARY_DIR}/data/com.uploadedlobster.peek.appdata.xml
-    DESTINATION share/metainfo)
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
 else()
   message(WARNING "Gettext >= ${GETTEXT_REQUIRED_VERSION} required for AppData file translation")
   install(
     FILES com.uploadedlobster.peek.appdata.xml.in
-    DESTINATION share/metainfo
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo
   RENAME com.uploadedlobster.peek.appdata.xml)
 endif()
 
 # Install application icons
-install(FILES "icons/16x16/com.uploadedlobster.peek.png" DESTINATION share/icons/hicolor/16x16/apps)
-install(FILES "icons/24x24/com.uploadedlobster.peek.png" DESTINATION share/icons/hicolor/24x24/apps)
-install(FILES "icons/32x32/com.uploadedlobster.peek.png" DESTINATION share/icons/hicolor/32x32/apps)
-install(FILES "icons/48x48/com.uploadedlobster.peek.png" DESTINATION share/icons/hicolor/48x48/apps)
-install(FILES "icons/64x64/com.uploadedlobster.peek.png" DESTINATION share/icons/hicolor/64x64/apps)
-install(FILES "icons/128x128/com.uploadedlobster.peek.png" DESTINATION share/icons/hicolor/128x128/apps)
-install(FILES "icons/256x256/com.uploadedlobster.peek.png" DESTINATION share/icons/hicolor/256x256/apps)
-install(FILES "icons/512x512/com.uploadedlobster.peek.png" DESTINATION share/icons/hicolor/512x512/apps)
+install(FILES "icons/16x16/com.uploadedlobster.peek.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/16x16/apps)
+install(FILES "icons/24x24/com.uploadedlobster.peek.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/24x24/apps)
+install(FILES "icons/32x32/com.uploadedlobster.peek.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/32x32/apps)
+install(FILES "icons/48x48/com.uploadedlobster.peek.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/48x48/apps)
+install(FILES "icons/64x64/com.uploadedlobster.peek.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/64x64/apps)
+install(FILES "icons/128x128/com.uploadedlobster.peek.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/128x128/apps)
+install(FILES "icons/256x256/com.uploadedlobster.peek.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/256x256/apps)
+install(FILES "icons/512x512/com.uploadedlobster.peek.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/512x512/apps)
 
 # Install DBus service
 configure_file (
@@ -68,7 +68,7 @@ configure_file (
   com.uploadedlobster.peek.service
   )
 
-install(FILES ${CMAKE_BINARY_DIR}/data/com.uploadedlobster.peek.service DESTINATION share/dbus-1/services)
+install(FILES ${CMAKE_BINARY_DIR}/data/com.uploadedlobster.peek.service DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dbus-1/services)
 
 # Copy build data FILES
 file(


### PR DESCRIPTION
This is handy if 'bin' and 'share' have different prefixes e.g. /usr/host/bin and /usr/share

Distributions like Exherbo don't use the 'classic' file system architecture, but instead use /usr/<host>/bin, to allow native cross compilation. However, share still is at it's usual location ( /usr/share )