### PR TITLE
Added instructions when installing Peek through snappy

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,6 @@ do the following command via command-line:
 
     sudo snap connect peek:gnome-3-26-1604 gnome-3-26-1604:gnome-3-26-1604
 
-
-
 Snaps should automatically update in the background. If this is not happening
 you can update Peek manually to the latest version:
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ environment or from command line:
 
     snap run peek
 
+In case it fails to start with the message `You need to connect this snap to the gnome platform snap` 
+do the following command via command-line:
+
+    sudo snap connect peek:gnome-3-26-platform gnome-3-24:gnome-3-24-platform
+
+
 Snaps should automatically update in the background. If this is not happening
 you can update Peek manually to the latest version:
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ environment or from command line:
 In case it fails to start with the message `You need to connect this snap to the gnome platform snap` 
 do the following command via command-line:
 
-    sudo snap connect peek:gnome-3-26-platform gnome-3-24:gnome-3-24-platform
+    sudo snap connect peek:gnome-3-26-1604 gnome-3-26-1604:gnome-3-26-1604
+
 
 
 Snaps should automatically update in the background. If this is not happening


### PR DESCRIPTION
The added instructions should help users connect gnome with Peek when installing it through Snappy. 