### PR TITLE
Bug fix for fallback_app_menu 

### DIFF
--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -502,7 +502,9 @@ namespace Peek.Ui {
 
       this.forall ((child)  => {
         if (child is Gtk.Popover) {
-          fallback_app_menu = child;
+          if (child.get_name() == (null)) {
+            fallback_app_menu = child;
+          }
         }
       });
 


### PR DESCRIPTION
#222 Added a conditional statement to get the widget name of all widgets who are of Gtk.Popover.. The widget name of the app_menu is (null) not sure why that is. So we check for the widget named (null) and set that as the fallback_app_menu.