### PR TITLE
Changed call to select_format at startup

### DIFF
--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -169,7 +169,7 @@ namespace Peek.Ui {
 
       // Set record button label
       // Grab the current format and set the record label with the selected format
-      select_format (this.recorder.config.output_format);
+      select_format (settings.get_string ("recording-output-format"));
     }
 
 


### PR DESCRIPTION
Fixed an issue were sometimes the record label is set incorrectly at startup.