### PR TITLE
Fixed elapsed timer

### DIFF
--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -265,7 +265,7 @@ namespace Peek.Ui {
       int seconds = 0;
       Timeout.add_seconds_full (GLib.Priority.LOW,1, () => {
         seconds += 1;
-        if (is_recording ) {
+        if (is_recording && !this.is_postprocessing) {
           headerbar.set_title("%02d:%02d".printf (seconds / 60, seconds % 60));
           return true;
         }


### PR DESCRIPTION
Fixed an issue where the time would continue after the recording has stopped and entered post processing.