### PR TITLE
WIP: Meson build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
-build*/
+build/
+build_*/
 
 CMakeCache.txt
 CMakeFiles/*

--- a/build-aux/meson/postinstall.py
+++ b/build-aux/meson/postinstall.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from os import environ, path
+from subprocess import call
+
+prefix = environ.get('MESON_INSTALL_PREFIX', '/usr/local')
+datadir = path.join(prefix, 'share')
+destdir = environ.get('DESTDIR', '')
+
+# Package managers set this so we don't need to run
+if not destdir:
+    print('Updating icon cache...')
+    call(['gtk-update-icon-cache', '-qtf', path.join(datadir, 'icons', 'hicolor')])
+
+    print('Updating desktop database...')
+    call(['update-desktop-database', '-q', path.join(datadir, 'applications')])
+
+    print('Compiling GSettings schemas...')
+    call(['glib-compile-schemas', path.join(datadir, 'glib-2.0', 'schemas')])
+
+

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -1,0 +1,8 @@
+icon_dir = join_paths(get_option('datadir'), 'icons/hicolor')
+
+icon_sizes = ['16x16', '24x24', '32x32', '48x48', '64x64', '128x128', '256x256', '512x512']
+
+foreach size : icon_sizes
+  install_data(size + '/com.uploadedlobster.peek.png',
+    install_dir: join_paths(icon_dir, size, 'apps'))
+endforeach

--- a/data/man/build_man.sh
+++ b/data/man/build_man.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+txt2man "$@" > ${MESON_BUILD_ROOT}/${MESON_SUBDIR}/peek.1

--- a/data/man/meson.build
+++ b/data/man/meson.build
@@ -1,0 +1,16 @@
+txt2man = find_program('txt2man', required: false)
+
+if not txt2man.found()
+  message('txt2man not found; man pages will not be generated.')
+else
+  message('Found txt2man; man page will be built and installed')
+  manpage = run_command([
+    join_paths(meson.current_source_dir(), 'build_man.sh'),
+    '-t', meson.project_name().to_upper(),
+    '-r', meson.project_version(),
+    '-s', '1',
+    '-v', '"User commands"',
+    join_paths(meson.current_source_dir(), 'peek.1.txt'),
+  ])
+  install_man(join_paths(meson.current_build_dir(), 'peek.1'))
+endif

--- a/data/meson.build
+++ b/data/meson.build
@@ -39,3 +39,15 @@ if compile_schemas.found()
     args: ['--strict', '--dry-run', meson.current_source_dir()]
   )
 endif
+
+configuration_data = configuration_data()
+# FIXME: That variable name is used as long as we have both cmake and meson builds
+configuration_data.set(
+  'CMAKE_INSTALL_FULL_BINDIR',
+  join_paths(get_option('prefix'), get_option('bindir')))
+configure_file(
+  input: 'com.uploadedlobster.peek.service.in',
+  output: 'com.uploadedlobster.peek.service',
+  configuration: configuration_data,
+  install_dir: join_paths(get_option('datadir'), 'dbus-1/services')
+)

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,41 @@
+desktop_file = i18n.merge_file(
+  input: 'com.uploadedlobster.peek.desktop.in',
+  output: 'com.uploadedlobster.peek.desktop',
+  type: 'desktop',
+  po_dir: '../po',
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'applications')
+)
+
+desktop_utils = find_program('desktop-file-validate', required: false)
+if desktop_utils.found()
+  test('Validate desktop file', desktop_utils,
+    args: [desktop_file]
+  )
+endif
+
+appstream_file = i18n.merge_file(
+  input: 'com.uploadedlobster.peek.appdata.xml.in',
+  output: 'com.uploadedlobster.peek.appdata.xml',
+  po_dir: '../po',
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'appdata')
+)
+
+appstream_util = find_program('appstream-util', required: false)
+if appstream_util.found()
+  test('Validate appstream file', appstream_util,
+    args: ['validate', appstream_file]
+  )
+endif
+
+install_data('com.uploadedlobster.peek.gschema.xml',
+  install_dir: join_paths(get_option('datadir'), 'glib-2.0/schemas')
+)
+
+compile_schemas = find_program('glib-compile-schemas', required: false)
+if compile_schemas.found()
+  test('Validate schema file', compile_schemas,
+    args: ['--strict', '--dry-run', meson.current_source_dir()]
+  )
+endif

--- a/data/meson.build
+++ b/data/meson.build
@@ -51,3 +51,6 @@ configure_file(
   configuration: configuration_data,
   install_dir: join_paths(get_option('datadir'), 'dbus-1/services')
 )
+
+subdir('icons')
+subdir('man')

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ i18n = import('i18n')
 
 subdir('data')
 subdir('src')
+subdir('tests')
 subdir('po')
 
 meson.add_install_script('build-aux/meson/postinstall.py')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,12 @@
+project('peek', ['c', 'vala'],
+  version: '1.3.1',
+  meson_version: '>= 0.40.0',
+)
+
+i18n = import('i18n')
+
+subdir('data')
+subdir('src')
+subdir('po')
+
+meson.add_install_script('build-aux/meson/postinstall.py')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('enable-filechoosernative', type : 'boolean', value : false)
+option('enable-gnome-shell',       type : 'boolean', value : true)
+option('enable-open-file-manager', type : 'boolean', value : true)

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,1 @@
+i18n.gettext(meson.project_name(), preset: 'glib')

--- a/src/meson.build
+++ b/src/meson.build
@@ -53,10 +53,19 @@ peek_deps = [
 
 gnome = import('gnome')
 
+configuration_data = configuration_data()
+configuration_data.set('PEEK_VERSION_FULL', meson.project_version())
+about_ui_file = configure_file(
+  input: '../ui/about.ui.in',
+  output: 'about.ui',
+  configuration: configuration_data
+)
+
 peek_sources += gnome.compile_resources('peek-resources',
   '../ui/peek.gresource.xml',
   source_dir: '../ui/',
-  c_name: 'peek'
+  c_name: 'peek',
+  dependencies: [about_ui_file]
 )
 
 executable('peek', peek_sources,

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,7 +34,7 @@ peek_sources = [
 
 add_project_arguments([
     '-DGETTEXT_PACKAGE="' + meson.project_name() + '"',
-    '-DLOCALEDIR="/usr/share/locale"',
+    '-DLOCALEDIR="' + join_paths(get_option('prefix'), get_option('localedir')) + '"',
     '-DVERSION="' + meson.project_version() + '"',
   ], language: 'c')
 
@@ -99,6 +99,7 @@ if not enable_open_file_manager
   vala_args += ['-D', 'DISABLE_OPEN_FILE_MANAGER']
 endif
 
+# Resource files
 configuration_data = configuration_data()
 configuration_data.set('PEEK_VERSION_FULL', meson.project_version())
 about_ui_file = configure_file(

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,72 @@
+peek_sources = [
+  'main.vala',
+  'application.vala',
+  'desktop-integration.vala',
+  'defaults.vala',
+  'errordomain.vala',
+  'gtk-helper.vala',
+  'utils.vala',
+  'dbus/freedesktop-dbus.vala',
+  'dbus/freedesktop-filemanager.vala',
+  'dbus/gnome-shell-screencast.vala',
+  'post-processing/cli-post-processor.vala',
+  'post-processing/extract-frames-post-processor.vala',
+  'post-processing/ffmpeg-post-processor.vala',
+  'post-processing/gifski-post-processor.vala',
+  'post-processing/post-processing-pipeline.vala',
+  'post-processing/post-processor.vala',
+  'recording/base-screen-recorder.vala',
+  'recording/cli-screen-recorder.vala',
+  'recording/ffmpeg-screen-recorder.vala',
+  'recording/ffmpeg.vala',
+  'recording/gnome-shell-dbus-recorder.vala',
+  'recording/recording-area.vala',
+  'recording/recording-config.vala',
+  'recording/screen-recorder-factory.vala',
+  'recording/screen-recorder.vala',
+  'ui/about-dialog.vala',
+  'ui/application-window.vala',
+  'ui/error-dialog.vala',
+  'ui/preferences-dialog.vala',
+  'ui/shortcut-label.vala',
+  'vapi/config.vapi',
+]
+
+add_project_arguments([
+    '--vapidir', join_paths(meson.current_source_dir(), 'vapi'),
+  ], language: 'vala')
+
+add_project_arguments([
+    '-DGETTEXT_PACKAGE="' + meson.project_name() + '"',
+    '-DLOCALEDIR="/usr/share/locale"',
+    '-DVERSION="' + meson.project_version() + '"',
+  ], language: 'c')
+
+peek_deps = [
+  dependency('cairo'),
+  dependency('gio-2.0', version: '>= 2.42'),
+  dependency('glib-2.0', version: '>= 2.38'),
+  dependency('gmodule-2.0'),
+  dependency('gtk+-3.0', version: '>= 3.14'),
+  dependency('keybinder-3.0'),
+]
+
+gnome = import('gnome')
+
+peek_sources += gnome.compile_resources('peek-resources',
+  '../ui/peek.gresource.xml',
+  source_dir: '../ui/',
+  c_name: 'peek'
+)
+
+executable('peek', peek_sources,
+  vala_args: [
+    '--target-glib=2.50',
+    '--pkg', 'posix',
+    '--header', 'application.h',
+    '--use-header',
+    '--includedir', '../..',
+  ],
+  dependencies: peek_deps,
+  install: true,
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -33,25 +33,70 @@ peek_sources = [
 ]
 
 add_project_arguments([
-    '--vapidir', join_paths(meson.current_source_dir(), 'vapi'),
-  ], language: 'vala')
-
-add_project_arguments([
     '-DGETTEXT_PACKAGE="' + meson.project_name() + '"',
     '-DLOCALEDIR="/usr/share/locale"',
     '-DVERSION="' + meson.project_version() + '"',
   ], language: 'c')
+
+vala_args = [
+  '--vapidir', join_paths(meson.current_source_dir(), 'vapi'),
+  '--pkg', 'posix',
+  '--header', 'application.h',
+  '--use-header',
+  '--includedir', '../..',
+]
+
+# Options
+enable_filechoosernative = get_option('enable-filechoosernative')
+enable_gnome_shell = get_option('enable-gnome-shell')
+enable_open_file_manager = get_option('enable-open-file-manager')
+
+# Dependencies
+gtk = dependency('gtk+-3.0', version: '>= 3.14')
+keybinder = dependency('keybinder-3.0', required: false)
 
 peek_deps = [
   dependency('cairo'),
   dependency('gio-2.0', version: '>= 2.42'),
   dependency('glib-2.0', version: '>= 2.38'),
   dependency('gmodule-2.0'),
-  dependency('gtk+-3.0', version: '>= 3.14'),
-  dependency('keybinder-3.0'),
+  gtk,
 ]
 
-gnome = import('gnome')
+if keybinder.found()
+  peek_deps += keybinder
+  vala_args += ['-D', 'HAS_KEYBINDER']
+endif
+
+# Feature configuration
+if gtk.version().version_compare('>= 3.16')
+  message('Compiling with features for GTK >= 3.16')
+  vala_args += ['-D', 'HAS_GTK_LABEL_XALIGN']
+endif
+
+if gtk.version().version_compare('>= 3.20')
+  message('Compiling with features for GTK >= 3.20')
+  if enable_filechoosernative
+    message('Compiling with Gtk.FileChooserNative')
+    vala_args += ['-D', 'HAS_GTK_FILECHOOSERNATIVE']
+  endif
+endif
+
+if gtk.version().version_compare('>= 3.22')
+  message('Compiling with features for GTK >= 3.22')
+  vala_args += ['-D', 'HAS_GTK_SHORTCUT_LABEL']
+  vala_args += ['-D', 'HAS_GTK_SHOW_URI_ON_WINDOW']
+endif
+
+if not enable_gnome_shell
+  message('GNOME Shell recorder disabled by configuration')
+  vala_args += ['-D', 'DISABLE_GNOME_SHELL']
+endif
+
+if not enable_open_file_manager
+  message('File manager integration disabled by configuration')
+  vala_args += ['-D', 'DISABLE_OPEN_FILE_MANAGER']
+endif
 
 configuration_data = configuration_data()
 configuration_data.set('PEEK_VERSION_FULL', meson.project_version())
@@ -61,6 +106,8 @@ about_ui_file = configure_file(
   configuration: configuration_data
 )
 
+gnome = import('gnome')
+
 peek_sources += gnome.compile_resources('peek-resources',
   '../ui/peek.gresource.xml',
   source_dir: '../ui/',
@@ -69,13 +116,7 @@ peek_sources += gnome.compile_resources('peek-resources',
 )
 
 executable('peek', peek_sources,
-  vala_args: [
-    '--target-glib=2.50',
-    '--pkg', 'posix',
-    '--header', 'application.h',
-    '--use-header',
-    '--includedir', '../..',
-  ],
+  vala_args: vala_args,
   dependencies: peek_deps,
   install: true,
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -44,6 +44,7 @@ vala_args = [
   '--header', 'application.h',
   '--use-header',
   '--includedir', '../..',
+  '--gresourcesdir', meson.current_build_dir(),
 ]
 
 # Options

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,48 @@
+# /desktop-integration/
+test_desktop_integration = executable('test-desktop-integration',
+  'test-desktop-integration.vala',
+  join_paths(meson.source_root(), 'src/desktop-integration.vala'),
+  join_paths(meson.source_root(), 'src/dbus/freedesktop-filemanager.vala'),
+  dependencies: [
+    dependency('gtk+-3.0'),
+  ],
+  install: false,
+)
+test('Testing desktop-integration', test_desktop_integration)
+
+# /utils/
+test_utils = executable('test-utils',
+  'test-utils.vala',
+  join_paths(meson.source_root(), 'src/defaults.vala'),
+  join_paths(meson.source_root(), 'src/utils.vala'),
+  dependencies: [
+    dependency('gtk+-3.0'),
+  ],
+  install: false,
+)
+test('Testing utils', test_utils)
+
+# /screen-recorder/recording-area/
+test_utils = executable('test-cli-screen-recorder',
+  'screen-recorder/test-cli-screen-recorder.vala',
+  join_paths(meson.source_root(), 'src/post-processing/cli-post-processor.vala'),
+  join_paths(meson.source_root(), 'src/post-processing/extract-frames-post-processor.vala'),
+  join_paths(meson.source_root(), 'src/post-processing/ffmpeg-post-processor.vala'),
+  join_paths(meson.source_root(), 'src/post-processing/gifski-post-processor.vala'),
+  join_paths(meson.source_root(), 'src/post-processing/post-processing-pipeline.vala'),
+  join_paths(meson.source_root(), 'src/post-processing/post-processor.vala'),
+  join_paths(meson.source_root(), 'src/recording/recording-area.vala'),
+  join_paths(meson.source_root(), 'src/recording/recording-config.vala'),
+  join_paths(meson.source_root(), 'src/recording/screen-recorder.vala'),
+  join_paths(meson.source_root(), 'src/recording/base-screen-recorder.vala'),
+  join_paths(meson.source_root(), 'src/recording/cli-screen-recorder.vala'),
+  join_paths(meson.source_root(), 'src/defaults.vala'),
+  join_paths(meson.source_root(), 'src/errordomain.vala'),
+  join_paths(meson.source_root(), 'src/utils.vala'),
+  vala_args: ['--pkg', 'posix'],
+  dependencies: [
+    dependency('gtk+-3.0'),
+  ],
+  install: false,
+)
+test('Testing cli-screen-recorder', test_utils)


### PR DESCRIPTION
This adds Meson based builds to Peek. The goal is to simplify the build structure and fix #312.

Things the current CMake build can and Meson not:

- [x] Build and run tests
- [ ] Compile gsettings schema locally for development builds (is it needed?)
- [x] Targets for updating i18n files (`peek-update-po`)
- [ ] Generate LINGUAS file (#320)

Things the current CMake build can and I don't plan to add to Meson:
- Debian package generation
- Uninstall target