### PR TITLE
Add instructions to install ffmpeg under Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ available. Use the repository `ppa:peek-developers/daily` in the above commands.
 There are no official Debian packages, yet, but you can easily create your own
 .deb package for Peek. First, install the build dependencies:
 
-    sudo apt install cmake valac libgtk-3-dev libkeybinder-3.0-dev libxml2-utils gettext txt2man
+    sudo apt install cmake valac libgtk-3-dev libkeybinder-3.0-dev libxml2-utils gettext txt2man ffmpeg
 
 Then build Peek and package it:
 


### PR DESCRIPTION
This avoids issues like https://github.com/phw/peek/issues/103

I am running Debian. _peek_ would work out of the box if _ffmpeg_ was added to the install instructions.

Maybe the error message (_Unable to create default screen recorder_) should say that neither ffmpeg nor avconv was found?

Alos, thanks for this, it works like a charm.