### PR TITLE
[RPM] Make gcc and vala dependencies explicit

### DIFF
--- a/rpm/peek.spec
+++ b/rpm/peek.spec
@@ -7,7 +7,9 @@ License:        GPLv3
 URL:            https://github.com/phw/peek
 Source0:        https://github.com/phw/peek/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
+BuildRequires:  gcc
 BuildRequires:  cmake
+BuildRequires:  vala
 BuildRequires:  vala-devel
 BuildRequires:  gettext
 BuildRequires:  pkgconfig(gtk+-3.0) >= 3.14


### PR DESCRIPTION
This is required by Fedora 30+. Changes do not break backward compatibility with F28/F29.

Build passes: https://copr.fedorainfracloud.org/coprs/dani/peek/build/848645/