### PR TITLE
Fix copy of non-existent gschema file

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -72,10 +72,4 @@ configure_file (
 
 install(FILES ${CMAKE_BINARY_DIR}/data/com.uploadedlobster.peek.service DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dbus-1/services)
 
-# Copy build data FILES
-file(
-  COPY com.canonical.Unity.gschema.xml
-  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/extra/
-)
-
 add_subdirectory(man)


### PR DESCRIPTION
This was a forgotten leftover of commit 2d984c7

Fixes the following cmake error:
```
CMake Error at data/CMakeLists.txt:76 (file):
  file COPY cannot find
  "/home/rdias/Projects/peek/data/com.canonical.Unity.gschema.xml".
```

Signed-off-by: Ricardo Dias <rdias@suse.com>