### PR TITLE
Add OARS rating

### DIFF
--- a/data/com.uploadedlobster.peek.appdata.xml.in
+++ b/data/com.uploadedlobster.peek.appdata.xml.in
@@ -80,6 +80,8 @@
 
   <developer_name>Philipp Wolfer</developer_name>
   <update_contact>ph.wolfer@gmail.com</update_contact>
+  
+  <content_rating type="oars-1.1" />
 
   <releases>
     <release version="1.3.1" date="2018-03-29" />


### PR DESCRIPTION
Add OARS rating that allows parental ratings in app stores https://hughsie.github.io/oars/

This is now a flathub requirement so at the very least we need a patch file.