### PR TITLE
Add meson build option for keybinder

### DIFF
--- a/BUILD_NOTES.md
+++ b/BUILD_NOTES.md
@@ -34,7 +34,7 @@ From inside the Peek source folder run:
 ### Debian package
 
 #### Build requirements
- - meson (>= 0.37.0)
+ - meson (>= 0.47.0)
  - valac (>= 0.22)
  - libgtk-3-dev (>= 3.20)
  - libkeybinder-3.0-dev

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Support for more Wayland desktops might be added in the future (see FAQs below).
 ### Development
 
 - Vala compiler >= 0.22
-- Meson >= 0.37.0
+- Meson >= 0.47.0
 - Gettext (>= 0.19 for localized .desktop entry)
 - txt2man (optional for building man page)
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('peek', ['c', 'vala'],
   version: '1.5.1',
-  meson_version: '>= 0.37.0',
+  meson_version: '>= 0.47.0',
 )
 
 add_project_arguments([

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('build-tests',              type : 'boolean', value : true)
+option('enable-keybinder',         type : 'feature', value : 'auto')
 option('enable-filechoosernative', type : 'boolean', value : false)
 option('enable-gnome-shell',       type : 'boolean', value : true)
 option('enable-open-file-manager', type : 'boolean', value : true)

--- a/src/meson.build
+++ b/src/meson.build
@@ -49,7 +49,7 @@ enable_open_file_manager = get_option('enable-open-file-manager')
 
 # Dependencies
 gtk = dependency('gtk+-3.0', version: '>= 3.20')
-keybinder = dependency('keybinder-3.0', required: false)
+keybinder = dependency('keybinder-3.0', required: get_option('enable-keybinder'))
 
 peek_deps = [
   dependency('cairo'),


### PR DESCRIPTION
This option was available in cmake build and allows packagers to explicitely build with/without keybinder (regardless of installed packages). I tried it when bumping peek package in Gentoo tree.