### PR TITLE
Fix appdata validation warning for summary tag

### DIFF
--- a/data/com.uploadedlobster.peek.appdata.xml.in
+++ b/data/com.uploadedlobster.peek.appdata.xml.in
@@ -5,9 +5,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>Peek</name>
-  <summary>
-    Simple screen recorder with an easy to use interface
-  </summary>
+  <summary>Simple screen recorder with an easy to use interface</summary>
 
   <description>
     <p>


### PR DESCRIPTION
Current appdata has error: summary-has-tabs-or-linebreaks.

```
% appstreamcli validate usr/share/metainfo/com.uploadedlobster.peek.appdata.xml
I: com.uploadedlobster.peek.desktop:355: url-not-secure http://peek.uploadedlobster.com
E: com.uploadedlobster.peek.desktop:32: summary-has-tabs-or-linebreaks
I: com.uploadedlobster.peek.desktop:349: nonstandard-gnome-extension kudos

Validation failed: errors: 1, infos: 2
```