### PR TITLE
Add fix for kde plasma

### DIFF
--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -181,6 +181,9 @@ namespace Peek.Ui {
         SettingsBindFlags.DEFAULT);
 
       // Configure window
+      if (DesktopIntegration.is_plasma () ) {
+        type_hint =NORMAL;
+      }
       this.set_keep_above (true);
       this.load_geometry ();
       this.on_window_screen_changed (null);


### PR DESCRIPTION
Setting the window hint type to utility does not seem to function well with plasma, peek will not show up in the task manager or task switcher. This checks if the user is using plasma and changes the hint type to normal.