### PR TITLE
KDE Plasma title bar fix

### DIFF
--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -107,6 +107,12 @@ namespace Peek.Ui {
             _ ("An unexpected error occurred during recording. Recording was aborted."),
             reason);
         } else {
+        
+         if (DesktopIntegration.is_plasma () ) {
+            headerbar.set_custom_title (null);
+            headerbar.set_title ("Peek");
+         }
+         
           stderr.printf ("Recording canceled\n");
         }
 

--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -297,6 +297,12 @@ namespace Peek.Ui {
 
         time_indicator_timeout = 0;
         headerbar.set_title ("");
+         
+        if (DesktopIntegration.is_plasma () ) {
+          headerbar.set_custom_title (null);
+          headerbar.set_title ("Peek");
+        }
+        
         return false;
       });
     }


### PR DESCRIPTION
On KDE Plasma after rendering recording the title bar text is left blank, this resolves that issue. Fixes #349