### PR TITLE
Different layout style of button group improves look and feel

### DIFF
--- a/ui/application-window.ui
+++ b/ui/application-window.ui
@@ -143,7 +143,7 @@ Author: Philipp Wolfer <ph.wolfer@gmail.com>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
             <property name="baseline_position">bottom</property>
-            <property name="layout_style">spread</property>
+            <property name="layout_style">expand</property>
             <child>
               <object class="GtkButton" id="stop_button">
                 <property name="label" translatable="yes">_Stop</property>


### PR DESCRIPTION
Changing the layout style property of action_button_box to expand makes the buttons inside the group look more integrated
Before:
![before](https://user-images.githubusercontent.com/9110024/107694102-beab0680-6c8d-11eb-96d9-16b1c922f955.png)

After:
![after](https://user-images.githubusercontent.com/9110024/107694119-c5397e00-6c8d-11eb-8308-1cf82635f4f3.png)

