### PR TITLE
Split Ubuntu install infos between 20.10+ and previous

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ for easy access. See the [AppImage wiki](https://github.com/AppImage/AppImageKit
 for more information on how to use AppImages and integrate them with your system.
 
 ### Ubuntu
+
+#### Ubuntu 20.10+
+
+Peek is available in official repositories.
+
+    sudo apt install peek
+    
+#### Before Ubuntu 20.10
+
 You can install the latest versions of Peek from the
 [Ubuntu PPA](https://code.launchpad.net/~peek-developers/+archive/ubuntu/stable).
 


### PR DESCRIPTION
Following https://github.com/phw/peek/issues/396#issuecomment-534505982 and https://github.com/phw/peek/issues/676#issuecomment-732081888.

Trying to add the PPA on latest ubuntu versions is failing. But it's not required since the officiel repositories contain Peek already. The README was not reflecting this.