### PR TITLE
Simplify Ubuntu installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ for easy access. See the [AppImage wiki](https://github.com/AppImage/AppImageKit
 for more information on how to use AppImages and integrate them with your system.
 
 ### Ubuntu
-Install the latest versions of Peek with this:
+Install the latest version of Peek with this:
 
     sudo apt install peek
 

--- a/README.md
+++ b/README.md
@@ -135,11 +135,8 @@ for easy access. See the [AppImage wiki](https://github.com/AppImage/AppImageKit
 for more information on how to use AppImages and integrate them with your system.
 
 ### Ubuntu
-You can install the latest versions of Peek from the
-[Ubuntu PPA](https://code.launchpad.net/~peek-developers/+archive/ubuntu/stable).
+Install the latest versions of Peek with this:
 
-    sudo add-apt-repository ppa:peek-developers/stable
-    sudo apt update
     sudo apt install peek
 
 If you want to use the latest development version there is also a


### PR DESCRIPTION
Since the latest release of Peek is available from the Ubuntu 20.04 repositories, there is no need to add PPA:
```
$ apt-cache policy peek
peek:
  Installed: 1.5.1-1
  Candidate: 1.5.1-1
  Version table:
 *** 1.5.1-1 500
        500 http://ubuntu.mirror.su.se/ubuntu focal/universe amd64 Packages
        100 /var/lib/dpkg/status
```