### PR TITLE
Symlink /usr/bin/python may not exist

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -6,6 +6,6 @@ add_project_arguments([
   ], language: 'c')
 
 run_target('peek-update-linguas',
-  command : ['python', '-c',
+  command : ['python3', '-c',
   'import os; print(" ".join((f[:-3] for f in sorted(os.listdir(".")) if f.endswith(".po"))), file=open("LINGUAS", "w"))'
 ])


### PR DESCRIPTION
I found a problem during the build RPM package for Alt Linux repository:
```
Program python found: NO
po/meson.build:8:0: ERROR: Program 'python' not found
```
Problem was solved by small fix.

That code is compatible with both python2 and python3,
but meson build system is in python3, so python3 is always installed.