### PR TITLE
Fix desktop integration for GNOME Flashback

### DIFF
--- a/src/desktop-integration.vala
+++ b/src/desktop-integration.vala
@@ -136,6 +136,10 @@ namespace Peek {
       return xdg_current_desktop_contains ("GNOME");
     }
 
+    public static bool is_gnome_shell () {
+      return is_gnome() && ! xdg_current_desktop_contains ("Flashback");
+    }
+
     public static bool is_cinnamon () {
       return xdg_current_desktop_contains ("X-Cinnamon");
     }

--- a/src/recording/gnome-shell-dbus-recorder.vala
+++ b/src/recording/gnome-shell-dbus-recorder.vala
@@ -92,7 +92,7 @@ namespace Peek.Recording {
     public static bool is_available () throws PeekError {
       // In theory the dbus service can be installed, but it will only work
       // if GNOME Shell is running.
-      if (!DesktopIntegration.is_gnome ()) {
+      if (!DesktopIntegration.is_gnome_shell ()) {
         return false;
       }
 


### PR DESCRIPTION
Flashback imitates Shell but does not support the Screencast method.

Fixes: #677, #770, #919
