### PR TITLE
Fix sound recording setting

### DIFF
--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -182,6 +182,10 @@ namespace Peek.Ui {
         this.recorder.config, "capture_mouse",
         SettingsBindFlags.DEFAULT);
 
+      settings.bind ("recording-capture-sound",
+        this.recorder.config, "capture_sound",
+        SettingsBindFlags.DEFAULT);
+
       settings.bind ("recording-start-delay",
         this, "recording_start_delay",
         SettingsBindFlags.DEFAULT);


### PR DESCRIPTION
Fixes https://github.com/phw/peek/issues/1061

The output file included an audio stream even when the sound recording setting was unchecked from the UI. 
The root cause was overlooking the UI-config linkage in #686.

With this change, I've ensured the file only includes the video stream. To validate the absence of an audio stream, you can use the following command:

```console
$ ffmpeg -i 'Peek 2023-09-11 01-21.webm' -hide_banner 2>&1 | grep Audio; echo $?
1
```
